### PR TITLE
fix(vcpkg): fix package name typo in vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "name": "design-pattern-cpp",
+  "name": "cpp-vcpkg-template",
   "version-string": "0.0.1",
   "dependencies": ["spdlog"],
   "builtin-baseline": "fba81a6a545a66ef3de3a2d36c355f687f72a6b4"


### PR DESCRIPTION
Fix package name typo in `vcpkg.json`.